### PR TITLE
Add Portfolio and PortfolioAccount support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 
 1. Write a feature or fix a bug
 2. Lint code: `docker exec retail-portfolio-backend uv run ruff check`
-3. Run type checks: `docker exec retail-portfolio-backend -T uv run basedpyright`
+3. Run type checks: `docker exec retail-portfolio-backend -T uv run basedpyright src`
 4. Run tests: `docker exec retail-portfolio-backend -T uv run pytest`
 5. Format code: `docker exec retail-portfolio-backend -T uv run ruff format`
 

--- a/migrations/versions/97f76d4f9b08_add_portfolios_and_portfolio_accounts.py
+++ b/migrations/versions/97f76d4f9b08_add_portfolios_and_portfolio_accounts.py
@@ -1,0 +1,51 @@
+"""add_portfolios_and_portfolio_accounts
+
+Revision ID: 97f76d4f9b08
+Revises: 2b3c4d5e6f7g
+Create Date: 2026-01-27 04:38:54.025870
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '97f76d4f9b08'
+down_revision: Union[str, Sequence[str], None] = '2b3c4d5e6f7g'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create portfolios table
+    op.create_table(
+        'portfolios',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='true'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE', name='fk_portfolios_user_id'),
+    )
+
+    # Create portfolio_accounts table
+    op.create_table(
+        'portfolio_accounts',
+        sa.Column('portfolio_id', sa.UUID(), nullable=False),
+        sa.Column('account_id', sa.UUID(), nullable=False),
+        sa.Column('added_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('portfolio_id', 'account_id'),
+        sa.ForeignKeyConstraint(['portfolio_id'], ['portfolios.id'], ondelete='CASCADE', name='fk_portfolio_accounts_portfolio_id'),
+        sa.ForeignKeyConstraint(['account_id'], ['accounts.id'], ondelete='CASCADE', name='fk_portfolio_accounts_account_id'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('portfolio_accounts')
+    op.drop_table('portfolios')

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -14,6 +14,8 @@ from . import (  # noqa: E402
     external_user,  # pyright: ignore[reportUnusedImport]
     institution,  # pyright: ignore[reportUnusedImport]
     note,  # pyright: ignore[reportUnusedImport]
+    portfolio,  # pyright: ignore[reportUnusedImport]
+    portfolio_account,  # pyright: ignore[reportUnusedImport]
     position,  # pyright: ignore[reportUnusedImport]
     reminder,  # pyright: ignore[reportUnusedImport]
     security,  # pyright: ignore[reportUnusedImport]

--- a/src/models/account.py
+++ b/src/models/account.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from .account_type import AccountType
     from .institution import Institution
     from .note import Note
+    from .portfolio_account import PortfolioAccount
     from .position import Position
     from .user import User
 
@@ -64,3 +65,6 @@ class Account(Base):
         "Position", back_populates="account"
     )
     notes: Mapped[list[Note]] = relationship("Note", back_populates="account")
+    portfolio_accounts: Mapped[list[PortfolioAccount]] = relationship(
+        "PortfolioAccount", back_populates="account"
+    )

--- a/src/models/portfolio.py
+++ b/src/models/portfolio.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+if TYPE_CHECKING:
+    from .portfolio_account import PortfolioAccount
+
+
+class Portfolio(Base):
+    """Portfolio model."""
+
+    __tablename__ = "portfolios"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now())
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+
+    # Relationships
+    portfolio_accounts: Mapped[list[PortfolioAccount]] = relationship(
+        "PortfolioAccount", back_populates="portfolio"
+    )

--- a/src/models/portfolio_account.py
+++ b/src/models/portfolio_account.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+if TYPE_CHECKING:
+    from .account import Account
+    from .portfolio import Portfolio
+
+
+class PortfolioAccount(Base):
+    """PortfolioAccount model - join table linking portfolios to accounts."""
+
+    __tablename__ = "portfolio_accounts"
+
+    # Composite primary key
+    portfolio_id: Mapped[UUID] = mapped_column(
+        ForeignKey("portfolios.id"), primary_key=True
+    )
+    account_id: Mapped[UUID] = mapped_column(
+        ForeignKey("accounts.id"), primary_key=True
+    )
+    added_at: Mapped[datetime] = mapped_column(DateTime, default=func.now())
+
+    # Relationships
+    portfolio: Mapped[Portfolio] = relationship(
+        "Portfolio", back_populates="portfolio_accounts"
+    )
+    account: Mapped[Account] = relationship(
+        "Account", back_populates="portfolio_accounts"
+    )

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -4,6 +4,12 @@ from .action_item import ActionItem
 from .external_user import FullExternalUser
 from .institution import Institution
 from .note import Note
+from .portfolio import (
+    PortfolioAccountRead,
+    PortfolioAccountWrite,
+    PortfolioRead,
+    PortfolioWrite,
+)
 from .position import Position
 from .reminder import Reminder
 from .security import Security
@@ -24,4 +30,8 @@ __all__ = [
     "Reminder",
     "ActionItem",
     "FullExternalUser",
+    "PortfolioRead",
+    "PortfolioWrite",
+    "PortfolioAccountRead",
+    "PortfolioAccountWrite",
 ]

--- a/src/schemas/portfolio.py
+++ b/src/schemas/portfolio.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PortfolioBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    name: str
+    description: str | None = None
+    user_id: UUID
+    is_active: bool = True
+    created_at: datetime | None = None
+
+
+class PortfolioRead(PortfolioBase):
+    id: UUID
+
+
+class PortfolioWrite(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    name: str
+    description: str | None = None
+    is_active: bool = True
+
+
+class PortfolioAccountBase(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    portfolio_id: UUID
+    account_id: UUID
+    added_at: datetime | None = None
+
+
+class PortfolioAccountRead(PortfolioAccountBase):
+    pass
+
+
+class PortfolioAccountWrite(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    portfolio_id: UUID
+    account_id: UUID


### PR DESCRIPTION
AI generated code - To be reviewed carefully

- Expose Portfolio and PortfolioAccount schemas in the API
- Add portfolio_accounts relationship on Account for Portfolios
- Export new models in models/__init__.py and schemas/__init__.py
- Update CLAUDE.md to run type checks with src path